### PR TITLE
chore: remove e-mail button from homepage

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -26,8 +26,6 @@ languages:
         url: https://github.com/adowair
       - name: linkedin
         url: https://linkedin.com/in/alidowair
-      - name: email
-        url: mailto:ali@dowair.com
   ar:
     weight: 2
     contentDir: content/
@@ -50,5 +48,3 @@ languages:
         url: https://github.com/adowair
       - name: linkedin
         url: https://linkedin.com/in/alidowair
-      - name: email
-        url: mailto:ali@dowair.com


### PR DESCRIPTION
This commit will remove the mailto button from the homepage in order to protect from web-crawling spam bots. A better solution to display my e-mail may come in the future.