### PR TITLE
setup: do not redirect to /en by default

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,7 +2,6 @@ baseURL: https://ali.dowair.com/
 theme: PaperMod
 
 defaultContentLanguage: en
-defaultContentLanguageInSubdir: true
 languages:
   en:
     title: Ali Dowair


### PR DESCRIPTION
This commit will remove the Hugo configurationn to redirect the default language page automatically. This redirect was problematic for the render PR preview workflow, so it will be removed until a better way to manage default redirects is found.