### PR TITLE
setup: let `site.baseURL` = "/"

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,6 @@
 baseURL: https://ali.dowair.com/
 theme: PaperMod
+baseUrl: "/"
 
 defaultContentLanguage: en
 languages:


### PR DESCRIPTION
This commit will override the `baseUrl` Hugo parameter to ensure that links are always rendered as relative. This is important in order for Render previews to work properly.