### PR TITLE
setup: disable site deploy via Github action

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -2,9 +2,9 @@
 name: Deploy Hugo site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+  # Runs on pushes targeting the default branch. Uncomment to enable.
+  # push:
+  #   branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This commit will disable automatic deploys of the website
through GitHub actions, as [Render](https://github.com/apps/render)
is already setup for automatic deployment. 